### PR TITLE
Add GermanTechJobs and remove invalid careerin.tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ A curated list of awesome niche job boards.
 ### Europe
 
 * [Landing.jobs](https://landing.jobs/?utm_source=github&utm_medium=referral&utm_content=whfio&utm_campaign=post)
-* [careerin.tech](https://careerin.tech) - Job board & company list for Berlin's tech & IT world
+* [GermanTechJobs.de](https://germantechjobs.de/) - Dedicated tech job board for Germany
 
 ### United States
 


### PR DESCRIPTION
It looks like https://careerin.tech/ is not working anymore, so I allowed myself a cleanup 😃 